### PR TITLE
handle unclosed connections

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -116,7 +116,11 @@ function execute() {
     data: null
   };
   return function (state) {
-    return _languageCommon.execute.apply(void 0, [createClient, connect].concat(operations, [disconnect, cleanupState]))(_objectSpread({}, initialState, {}, state));
+    return _languageCommon.execute.apply(void 0, [createClient, connect].concat(operations, [disconnect, cleanupState]))(_objectSpread({}, initialState, {}, state))["catch"](function (e) {
+      console.error(e);
+      console.error('Unhandled error in the operations. Exiting process.');
+      process.exit(1);
+    });
   };
 }
 

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -30,7 +30,11 @@ export function execute(...operations) {
       ...operations,
       disconnect,
       cleanupState
-    )({ ...initialState, ...state });
+    )({ ...initialState, ...state }).catch(e => {
+      console.error(e);
+      console.error('Unhandled error in the operations. Exiting process.');
+      process.exit(1);
+    });
   };
 }
 


### PR DESCRIPTION
@lakhassane , see: https://github.com/OpenFn/language-mssql/releases/tag/v2.1.1 

I'd like to implement the same thing for postgres. Have you ever noticed that certain errors (outside your helper functions) lead to zombie processes? I think this should handle it. Looking forward to your review.