### PR TITLE
capture raw_sql for table operations in references for #58

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -128,7 +128,8 @@ function execute() {
 
   var initialState = {
     references: [],
-    data: null
+    data: null,
+    queries: []
   };
   return function (state) {
     return _languageCommon.execute.apply(void 0, [createClient, connect].concat(operations, [disconnect, cleanupState]))(_objectSpread({}, initialState, {}, state))["catch"](function (e) {
@@ -341,17 +342,19 @@ function insertMany(table, records) {
  * upsert(
  *  'users', // the DB table
  *  'ON CONSTRAINT users_pkey', // a DB column with a unique constraint OR a CONSTRAINT NAME
- *  {name: 'Elodie', id: 7}
+ *  {name: 'Elodie', id: 7},
+ *  {writeSql:true, execute: true}
  * )
  * @constructor
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {object} record - Payload data for the record as a JS object
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function upsert(table, uuid, record) {
+function upsert(table, uuid, record, options) {
   return function (state) {
     var client = state.client;
 
@@ -369,24 +372,41 @@ function upsert(table, uuid, record) {
       var insertValues = (0, _pgFormat["default"])("INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES (%L)"), values);
       var query = "".concat(insertValues, "\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
       var safeQuery = "INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES [--REDACTED--]\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
-      return new Promise(function (resolve, reject) {
-        console.log("Executing upsert via : ".concat(safeQuery));
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
+
+      exports.execute = execute = function execute() {
+        return new Promise(function (resolve, reject) {
+          console.log("Executing upsert via : ".concat(safeQuery));
+          client.query(query, function (err, result) {
+            if (err) {
+              reject(err);
+              client.end();
+            } else {
+              console.log(result);
+              resolve(result);
+            }
+          });
+        }).then(function (data) {
+          return _objectSpread({}, state, {
+            response: {
+              body: data
+            }
+          });
         });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          response: {
-            body: data
-          }
-        });
-      });
+      };
+
+      if (options) {
+        if (options.writeSql) {
+          state.queries.push(query);
+        }
+
+        if (options.execute) {
+          return execute();
+        }
+      } else {
+        return execute();
+      }
+
+      return state;
     } catch (e) {
       console.log(e);
       client.end();

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -89,6 +89,18 @@ var _pgFormat = _interopRequireDefault(require("pg-format"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -516,6 +528,7 @@ function insertTable(table, records) {
         });
       }).then(function (data) {
         return _objectSpread({}, state, {
+          references: [].concat(_toConsumableArray(references), [query]),
           response: {
             body: data
           }
@@ -562,6 +575,7 @@ function modifyTable(table, records) {
         });
       }).then(function (data) {
         return _objectSpread({}, state, {
+          references: [].concat(_toConsumableArray(references), [query]),
           response: {
             body: data
           }

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -187,6 +187,26 @@ function cleanupState(state) {
   delete state.client;
   return state;
 }
+
+function runQuery(state, client, query) {
+  return new Promise(function (resolve, reject) {
+    client.query(query, function (err, result) {
+      if (err) {
+        reject(err);
+        client.end();
+      } else {
+        console.log(result);
+        resolve(result);
+      }
+    });
+  }).then(function (data) {
+    return _objectSpread({}, state, {
+      response: {
+        body: data
+      }
+    });
+  });
+}
 /**
  * Execute an SQL statement
  * @public
@@ -373,37 +393,18 @@ function upsert(table, uuid, record, options) {
       var query = "".concat(insertValues, "\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
       var safeQuery = "INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES [--REDACTED--]\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
 
-      exports.execute = execute = function execute() {
-        return new Promise(function (resolve, reject) {
-          console.log("Executing upsert via : ".concat(safeQuery));
-          client.query(query, function (err, result) {
-            if (err) {
-              reject(err);
-              client.end();
-            } else {
-              console.log(result);
-              resolve(result);
-            }
-          });
-        }).then(function (data) {
-          return _objectSpread({}, state, {
-            response: {
-              body: data
-            }
-          });
-        });
-      };
-
       if (options) {
         if (options.writeSql) {
           state.queries.push(query);
         }
 
         if (options.execute) {
-          return execute();
+          console.log("Executing upsert via : ".concat(query));
+          return runQuery(state, client, query);
         }
       } else {
-        return execute();
+        console.log("Executing upsert via : ".concat(query));
+        return runQuery(state, client, query);
       }
 
       return state;

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -528,7 +528,7 @@ function insertTable(table, records) {
         });
       }).then(function (data) {
         return _objectSpread({}, state, {
-          references: [].concat(_toConsumableArray(references), [query]),
+          references: [].concat(_toConsumableArray(state.references), [query]),
           response: {
             body: data
           }
@@ -575,7 +575,7 @@ function modifyTable(table, records) {
         });
       }).then(function (data) {
         return _objectSpread({}, state, {
-          references: [].concat(_toConsumableArray(references), [query]),
+          references: [].concat(_toConsumableArray(state.references), [query]),
           response: {
             body: data
           }

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -213,10 +213,11 @@ function queryHandler(state, query, options) {
  * @public
  * @example
  * execute(
- *   sql(sqlQuery)
+ *   sql(sqlQuery, { writeSql: true })
  * )(state)
  * @constructor
- * @param {object} sqlQuery - Payload data for the message
+ * @param {function} sqlQuery - a function which takes state and returns a
+ * string of SQL.
  * @param {object} options - Optional options argument
  * @returns {Operation}
  */
@@ -443,7 +444,7 @@ function insertTable(table, records, options) {
         return "".concat(x.name, " ").concat(x.type, " ").concat(x.required ? 'NOT NULL' : '');
       }).join(', ');
       var query = "CREATE TABLE ".concat(table, " (\n        ").concat(structureData, "\n      );");
-      console.log('Creating table via:', query);
+      console.log('Preparing to create table via:', query);
       return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
@@ -474,7 +475,7 @@ function modifyTable(table, records, options) {
         return "ADD COLUMN ".concat(x.name, " ").concat(x.type, " ").concat(x.required ? 'NOT NULL' : '');
       }).join(', ');
       var query = "ALTER TABLE ".concat(table, "\n        ").concat(structureData, "\n      ;");
-      console.log('Creating table via:', query);
+      console.log('Preparing to modify table via:', query);
       return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -89,18 +89,6 @@ var _pgFormat = _interopRequireDefault(require("pg-format"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
-
-function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
-
-function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
@@ -188,8 +176,21 @@ function cleanupState(state) {
   return state;
 }
 
-function runQuery(state, client, query) {
+function queryHandler(state, query, options) {
+  var client = state.client;
   return new Promise(function (resolve, reject) {
+    if (options) {
+      if (options.writeSql) {
+        console.log('Adding prepared SQL to state.queries array.');
+        state.queries.push(query);
+      }
+
+      if (options.execute === false) {
+        console.log('Not executing query; options.execute === false');
+        resolve('Query not executed.');
+      }
+    }
+
     client.query(query, function (err, result) {
       if (err) {
         reject(err);
@@ -216,38 +217,19 @@ function runQuery(state, client, query) {
  * )(state)
  * @constructor
  * @param {object} sqlQuery - Payload data for the message
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function sql(sqlQuery) {
+function sql(sqlQuery, options) {
   return function (state) {
     var client = state.client;
 
     try {
       var body = sqlQuery(state);
-      console.log('Executing SQL statement.');
-      return new Promise(function (resolve, reject) {
-        // execute a query on our database
-        client.query(body, function (err, result) {
-          if (err) {
-            reject(err); // Disconnect if there's an error.
-
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        var nextState = _objectSpread({}, state, {
-          response: {
-            body: data
-          }
-        });
-
-        return nextState;
-      });
+      console.log('Preparing to execute sql statement');
+      return queryHandler(state, body, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -262,11 +244,12 @@ function sql(sqlQuery) {
  * @constructor
  * @param {string} table - The target table
  * @param {object} record - Payload data for the record as a JS object
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function insert(table, record) {
+function insert(table, record, options) {
   return function (state) {
     var client = state.client;
 
@@ -279,24 +262,8 @@ function insert(table, record) {
       });
       var query = (0, _pgFormat["default"])("INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES (%L);"), values);
       var safeQuery = "INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES [--REDACTED--]];");
-      return new Promise(function (resolve, reject) {
-        console.log("Executing insert via : ".concat(safeQuery));
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          response: {
-            body: data
-          }
-        });
-      });
+      console.log('Preparing to insert via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -311,11 +278,12 @@ function insert(table, record) {
  * @constructor
  * @param {string} table - The target table
  * @param {function} records - A function that takes state and returns an array of records
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function insertMany(table, records) {
+function insertMany(table, records, options) {
   return function (state) {
     var client = state.client;
 
@@ -329,26 +297,8 @@ function insertMany(table, records) {
       });
       var query = (0, _pgFormat["default"])("INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES %L;"), valueSets);
       var safeQuery = "INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES [--REDACTED--]];");
-      return new Promise(function (resolve, reject) {
-        console.log("Executing insert many via: ".concat(safeQuery)); // execute a query on our database
-
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err); // Disconnect if there's an error.
-
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          response: {
-            body: data
-          }
-        });
-      });
+      console.log('Preparing to insertMany via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -392,22 +342,8 @@ function upsert(table, uuid, record, options) {
       var insertValues = (0, _pgFormat["default"])("INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES (%L)"), values);
       var query = "".concat(insertValues, "\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
       var safeQuery = "INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES [--REDACTED--]\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
-
-      if (options) {
-        if (options.writeSql) {
-          state.queries.push(query);
-        }
-
-        if (options.execute) {
-          console.log("Executing upsert via : ".concat(query));
-          return runQuery(state, client, query);
-        }
-      } else {
-        console.log("Executing upsert via : ".concat(query));
-        return runQuery(state, client, query);
-      }
-
-      return state;
+      console.log('Preparing to upsert via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -427,11 +363,12 @@ function upsert(table, uuid, record, options) {
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {function} records - A function that takes state and returns an array of records
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function upsertMany(table, uuid, records) {
+function upsertMany(table, uuid, records, options) {
   return function (state) {
     var client = state.client;
 
@@ -449,24 +386,8 @@ function upsertMany(table, uuid, records) {
       var insertValues = (0, _pgFormat["default"])("INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES %L"), values);
       var query = "".concat(insertValues, "\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
       var safeQuery = "INSERT INTO ".concat(table, " (").concat(columnsList, ") VALUES [--REDACTED--]\n        ON CONFLICT ").concat(conflict, "\n        DO UPDATE SET ").concat(updateValues, ";");
-      return new Promise(function (resolve, reject) {
-        console.log("Executing upsert via : ".concat(safeQuery));
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          response: {
-            body: data
-          }
-        });
-      });
+      console.log('Preparing to upsert via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -480,34 +401,19 @@ function upsertMany(table, uuid, records) {
  * describeTable('table_name')
  * @constructor
  * @param {string} table - The name of the table to describe
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function describeTable(table) {
+function describeTable(table, options) {
   return function (state) {
     var client = state.client;
 
     try {
       var query = "SELECT column_name, udt_name, is_nullable\n        FROM information_schema.columns\n        WHERE table_name='".concat(table, "';");
-      return new Promise(function (resolve, reject) {
-        console.log("Describing table via : ".concat(query));
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            //console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          table_data: {
-            body: data
-          }
-        });
-      });
+      console.log('Preparing to describle table via:', query);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -522,11 +428,12 @@ function describeTable(table) {
  * @constructor
  * @param {string} table - The new table to create
  * @param {function} records - An array of form columns
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function insertTable(table, records) {
+function insertTable(table, records, options) {
   return function (state) {
     var client = state.client;
 
@@ -536,25 +443,8 @@ function insertTable(table, records) {
         return "".concat(x.name, " ").concat(x.type, " ").concat(x.required ? 'NOT NULL' : '');
       }).join(', ');
       var query = "CREATE TABLE ".concat(table, " (\n        ").concat(structureData, "\n      );");
-      return new Promise(function (resolve, reject) {
-        console.log("Creating table via : ".concat(query));
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          references: [].concat(_toConsumableArray(state.references), [query]),
-          response: {
-            body: data
-          }
-        });
-      });
+      console.log('Creating table via:', query);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -569,11 +459,12 @@ function insertTable(table, records) {
  * @constructor
  * @param {string} table - The name of the table to alter
  * @param {function} records - An array of form columns
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
 
 
-function modifyTable(table, records) {
+function modifyTable(table, records, options) {
   return function (state) {
     var client = state.client;
 
@@ -583,25 +474,8 @@ function modifyTable(table, records) {
         return "ADD COLUMN ".concat(x.name, " ").concat(x.type, " ").concat(x.required ? 'NOT NULL' : '');
       }).join(', ');
       var query = "ALTER TABLE ".concat(table, "\n        ").concat(structureData, "\n      ;");
-      return new Promise(function (resolve, reject) {
-        console.log("Altering table via : ".concat(query));
-        client.query(query, function (err, result) {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(function (data) {
-        return _objectSpread({}, state, {
-          references: [].concat(_toConsumableArray(state.references), [query]),
-          response: {
-            body: data
-          }
-        });
-      });
+      console.log('Creating table via:', query);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -433,7 +433,7 @@ export function insertTable(table, records) {
       }).then(data => {
         return {
           ...state,
-          references: [...references, query],
+          references: [...state.references, query],
           response: { body: data },
         };
       });
@@ -485,7 +485,7 @@ export function modifyTable(table, records) {
       }).then(data => {
         return {
           ...state,
-          references: [...references, query],
+          references: [...state.references, query],
           response: { body: data },
         };
       });

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -113,10 +113,11 @@ function queryHandler(state, query, options) {
  * @public
  * @example
  * execute(
- *   sql(sqlQuery)
+ *   sql(sqlQuery, { writeSql: true })
  * )(state)
  * @constructor
- * @param {object} sqlQuery - Payload data for the message
+ * @param {function} sqlQuery - a function which takes state and returns a
+ * string of SQL.
  * @param {object} options - Optional options argument
  * @returns {Operation}
  */
@@ -375,7 +376,7 @@ export function insertTable(table, records, options) {
         ${structureData}
       );`;
 
-      console.log('Creating table via:', query);
+      console.log('Preparing to create table via:', query);
       return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
@@ -411,7 +412,7 @@ export function modifyTable(table, records, options) {
         ${structureData}
       ;`;
 
-      console.log('Creating table via:', query);
+      console.log('Preparing to modify table via:', query);
       return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -82,14 +82,16 @@ function cleanupState(state) {
 function queryHandler(state, query, options) {
   const { client } = state;
   return new Promise((resolve, reject) => {
-    if (options.writeSql) {
-      console.log('Adding prepared SQL to state.queries array.');
-      state.queries.push(query);
-    }
+    if (options) {
+      if (options.writeSql) {
+        console.log('Adding prepared SQL to state.queries array.');
+        state.queries.push(query);
+      }
 
-    if (options.execute === false) {
-      console.log('Not executing query; options.execute === false');
-      resolve('Query not executed.');
+      if (options.execute === false) {
+        console.log('Not executing query; options.execute === false');
+        resolve('Query not executed.');
+      }
     }
 
     client.query(query, (err, result) => {
@@ -115,32 +117,18 @@ function queryHandler(state, query, options) {
  * )(state)
  * @constructor
  * @param {object} sqlQuery - Payload data for the message
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function sql(sqlQuery) {
+export function sql(sqlQuery, options) {
   return state => {
     let { client } = state;
 
     try {
       const body = sqlQuery(state);
-      console.log('Executing SQL statement.');
 
-      return new Promise((resolve, reject) => {
-        // execute a query on our database
-        client.query(body, function (err, result) {
-          if (err) {
-            reject(err);
-            // Disconnect if there's an error.
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        const nextState = { ...state, response: { body: data } };
-        return nextState;
-      });
+      console.log('Preparing to execute sql statement');
+      return queryHandler(state, body, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -156,9 +144,10 @@ export function sql(sqlQuery) {
  * @constructor
  * @param {string} table - The target table
  * @param {object} record - Payload data for the record as a JS object
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function insert(table, record) {
+export function insert(table, record, options) {
   return state => {
     const { client } = state;
 
@@ -175,21 +164,8 @@ export function insert(table, record) {
 
       const safeQuery = `INSERT INTO ${table} (${columnsList}) VALUES [--REDACTED--]];`;
 
-      return new Promise((resolve, reject) => {
-        console.log(`Executing insert via : ${safeQuery}`);
-
-        client.query(query, (err, result) => {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        return { ...state, response: { body: data } };
-      });
+      console.log('Preparing to insert via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -205,9 +181,10 @@ export function insert(table, record) {
  * @constructor
  * @param {string} table - The target table
  * @param {function} records - A function that takes state and returns an array of records
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function insertMany(table, records) {
+export function insertMany(table, records, options) {
   return state => {
     let { client } = state;
 
@@ -225,22 +202,8 @@ export function insertMany(table, records) {
 
       const safeQuery = `INSERT INTO ${table} (${columnsList}) VALUES [--REDACTED--]];`;
 
-      return new Promise((resolve, reject) => {
-        console.log(`Executing insert many via: ${safeQuery}`);
-        // execute a query on our database
-        client.query(query, (err, result) => {
-          if (err) {
-            reject(err);
-            // Disconnect if there's an error.
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        return { ...state, response: { body: data } };
-      });
+      console.log('Preparing to insertMany via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -317,9 +280,10 @@ export function upsert(table, uuid, record, options) {
  * @param {string} table - The target table
  * @param {string} uuid - The uuid column to determine a matching/existing record
  * @param {function} records - A function that takes state and returns an array of records
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function upsertMany(table, uuid, records) {
+export function upsertMany(table, uuid, records, options) {
   return state => {
     let { client } = state;
 
@@ -349,20 +313,8 @@ export function upsertMany(table, uuid, records) {
         ON CONFLICT ${conflict}
         DO UPDATE SET ${updateValues};`;
 
-      return new Promise((resolve, reject) => {
-        console.log(`Executing upsert via : ${safeQuery}`);
-        client.query(query, (err, result) => {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        return { ...state, response: { body: data } };
-      });
+      console.log('Preparing to upsert via:', safeQuery);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -377,9 +329,10 @@ export function upsertMany(table, uuid, records) {
  * describeTable('table_name')
  * @constructor
  * @param {string} table - The name of the table to describe
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function describeTable(table) {
+export function describeTable(table, options) {
   return state => {
     let { client } = state;
 
@@ -388,21 +341,8 @@ export function describeTable(table) {
         FROM information_schema.columns
         WHERE table_name='${table}';`;
 
-      return new Promise((resolve, reject) => {
-        console.log(`Describing table via : ${query}`);
-
-        client.query(query, (err, result) => {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            //console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        return { ...state, table_data: { body: data } };
-      });
+      console.log('Preparing to describle table via:', query);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -418,9 +358,10 @@ export function describeTable(table) {
  * @constructor
  * @param {string} table - The new table to create
  * @param {function} records - An array of form columns
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function insertTable(table, records) {
+export function insertTable(table, records, options) {
   return state => {
     let { client } = state;
 
@@ -434,25 +375,8 @@ export function insertTable(table, records) {
         ${structureData}
       );`;
 
-      return new Promise((resolve, reject) => {
-        console.log(`Creating table via : ${query}`);
-
-        client.query(query, (err, result) => {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        return {
-          ...state,
-          references: [...state.references, query],
-          response: { body: data },
-        };
-      });
+      console.log('Creating table via:', query);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();
@@ -468,9 +392,10 @@ export function insertTable(table, records) {
  * @constructor
  * @param {string} table - The name of the table to alter
  * @param {function} records - An array of form columns
+ * @param {object} options - Optional options argument
  * @returns {Operation}
  */
-export function modifyTable(table, records) {
+export function modifyTable(table, records, options) {
   return state => {
     let { client } = state;
 
@@ -486,25 +411,8 @@ export function modifyTable(table, records) {
         ${structureData}
       ;`;
 
-      return new Promise((resolve, reject) => {
-        console.log(`Altering table via : ${query}`);
-
-        client.query(query, (err, result) => {
-          if (err) {
-            reject(err);
-            client.end();
-          } else {
-            console.log(result);
-            resolve(result);
-          }
-        });
-      }).then(data => {
-        return {
-          ...state,
-          references: [...state.references, query],
-          response: { body: data },
-        };
-      });
+      console.log('Creating table via:', query);
+      return queryHandler(state, query, options);
     } catch (e) {
       console.log(e);
       client.end();

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -431,7 +431,11 @@ export function insertTable(table, records) {
           }
         });
       }).then(data => {
-        return { ...state, response: { body: data } };
+        return {
+          ...state,
+          references: [...references, query],
+          response: { body: data },
+        };
       });
     } catch (e) {
       console.log(e);
@@ -479,7 +483,11 @@ export function modifyTable(table, records) {
           }
         });
       }).then(data => {
-        return { ...state, response: { body: data } };
+        return {
+          ...state,
+          references: [...references, query],
+          response: { body: data },
+        };
       });
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
For https://github.com/OpenFn/wcs/issues/58 , could we add `console.log(references)` at the end of the job? we could also provide a "mock only" argument to the metadata functions that made them output but not execute their sql. Thoughts?